### PR TITLE
fix(docker): Use the correct ENV_FILE_PATH for setup container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,7 +60,7 @@ services:
       dockerfile: Dockerfile
       target: local-setup
     environment:
-      ENV_FILE_PATH: local_volume/.env
+      ENV_FILE_PATH: .env.local
     volumes:
       - "local-data:/usr/src/app/local_volume"
 volumes:


### PR DESCRIPTION
## Overview

This uses the the correct `ENV_FILE_PATH` environment variable for the `setup` container. `local_volume/.env` doesn't exist when the container is first created and `local-setup.sh` is run.